### PR TITLE
Fix error type of attachments property in the ClassworkMaterial model

### DIFF
--- a/packages/server/src/modules/classwork/models/ClassworkMaterial.ts
+++ b/packages/server/src/modules/classwork/models/ClassworkMaterial.ts
@@ -1,6 +1,6 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql'
 import { prop } from '@typegoose/typegoose'
-// import { Types } from 'mongoose'
+import { Types } from 'mongoose'
 
 import { BaseModel, Publication } from 'core'
 


### PR DESCRIPTION
Fix error type of **attachments** property in the ClassworkMaterial model